### PR TITLE
Update the README.md to reflect the correct usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ func main() {
 	}
 
 	// Initialise the client.
-	client, err := notify.Client.New(config)
+	client, err := notify.New(config)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
This is just a small change - it turns out to create a new `Client` here you don't actually need `.Client`, just `.New(config)`